### PR TITLE
feat: extend device.capabilities for software capabilities

### DIFF
--- a/v1/openapi.yaml
+++ b/v1/openapi.yaml
@@ -444,8 +444,10 @@ components:
             List of device capabilities (hardware and software). Defined values:
             audio_out, audio_in, display, haptic, camera. Implementations MAY
             define additional capabilities. Unknown capabilities MUST be ignored
-            by backends. Platform-specific capabilities SHOULD use a namespace
-            prefix to avoid collisions (e.g., `openclaw:exec_approvals`).
+            by backends. Standard capabilities use plain identifiers (e.g.,
+            `skills`, `cron`, `workflows`). Platform-specific capabilities
+            SHOULD use a namespace prefix to avoid collisions (e.g.,
+            `openclaw:exec_approvals`, `ha:scenes`).
           items:
             type: string
           example:

--- a/v1/openapi.yaml
+++ b/v1/openapi.yaml
@@ -436,13 +436,16 @@ components:
             - speaker
             - terminal
             - embedded
+            - agent_platform
           example: ios
         capabilities:
           type: array
           description: |
-            List of device capabilities. Defined values: audio_out, audio_in,
-            display, haptic, camera. Implementations MAY define additional
-            capabilities. Unknown capabilities MUST be ignored by backends.
+            List of device capabilities (hardware and software). Defined values:
+            audio_out, audio_in, display, haptic, camera. Implementations MAY
+            define additional capabilities. Unknown capabilities MUST be ignored
+            by backends. Platform-specific capabilities SHOULD use a namespace
+            prefix to avoid collisions (e.g., `openclaw:exec_approvals`).
           items:
             type: string
           example:

--- a/v1/spec.md
+++ b/v1/spec.md
@@ -192,10 +192,12 @@ Device metadata. Allows Yodel-aware backends to adapt responses based on client 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `device.type` | String | No | Device type: `ios`, `android`, `web`, `car`, `speaker`, `terminal`, `embedded`. |
-| `device.capabilities` | Array\<String\> | No | List of device capabilities. |
+| `device.type` | String | No | Device type: `ios`, `android`, `web`, `car`, `speaker`, `terminal`, `embedded`, `agent_platform`. |
+| `device.capabilities` | Array\<String\> | No | List of device capabilities (hardware and software). |
 
 **Defined capabilities:**
+
+Capabilities describe what the client can do — regardless of whether the capability is hardware or software. A backend uses this list to adapt its responses (e.g., skip TTS when `audio_out` is absent, offer workflow triggers when `workflows` is present).
 
 | Capability | Description |
 |------------|-------------|
@@ -206,6 +208,8 @@ Device metadata. Allows Yodel-aware backends to adapt responses based on client 
 | `camera` | Device has a camera. |
 
 Additional capabilities MAY be defined by implementations. Unknown capabilities MUST be ignored by backends.
+
+**Namespacing convention:** Standard capabilities that apply across platforms use plain identifiers (e.g., `skills`, `cron`, `workflows`). Platform-specific capabilities SHOULD use a namespace prefix to avoid collisions (e.g., `openclaw:exec_approvals`, `ha:scenes`).
 
 ---
 
@@ -643,7 +647,7 @@ yodel
 │   ├── provider     String
 │   └── format       String (opus | mp3 | wav | aac)
 ├── device
-│   ├── type         String (ios | android | web | car | speaker | terminal | embedded)
+│   ├── type         String (ios | android | web | car | speaker | terminal | embedded | agent_platform)
 │   └── capabilities Array<String>
 ```
 


### PR DESCRIPTION
## Summary
- Add `agent_platform` to `device.type` enum for platforms like OpenClaw, n8n, Home Assistant
- Clarify that `device.capabilities` covers both hardware and software capabilities
- Add namespacing convention for platform-specific capabilities (e.g., `openclaw:exec_approvals`, `ha:scenes`)
- Sync all changes in `spec.md` and `openapi.yaml`

Implements the decision from #8.

## Changes
- **§6.4.3** (`spec.md`): `agent_platform` device type, intro paragraph for capabilities, namespacing convention
- **Appendix B** (`spec.md`): Updated device type list
- **`openapi.yaml`**: `agent_platform` in enum, updated capabilities description

## Test plan
- [x] Verify spec.md renders correctly on GitHub
- [x] Verify openapi.yaml validates (no breaking schema changes)
- [x] Confirm no existing device types or capabilities are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)